### PR TITLE
Add support of unix sockets for tcp, http, https listeners

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -131,6 +131,8 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.String("https-address", opts.HTTPSAddress, "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.String("http-address", opts.HTTPAddress, "<addr>:<port> to listen on for HTTP clients")
 	flagSet.String("tcp-address", opts.TCPAddress, "<addr>:<port> to listen on for TCP clients")
+	flagSet.Bool("use-unix-sockets", opts.UseUnixSockets, "Usinx UNIX sockets instead of IP sockets")
+
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> or a full url to query auth server (may be given multiple times)")
 	flagSet.String("broadcast-address", opts.BroadcastAddress, "address that will be registered with lookupd (defaults to the OS hostname)")

--- a/internal/http_api/api_request.go
+++ b/internal/http_api/api_request.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -121,7 +120,7 @@ retry:
 
 func httpsEndpoint(endpoint string, body []byte) (string, error) {
 	var forbiddenResp struct {
-		HTTPSPort int `json:"https_port"`
+		HTTPSAddr string `json:"https_addr"`
 	}
 	err := json.Unmarshal(body, &forbiddenResp)
 	if err != nil {
@@ -133,12 +132,7 @@ func httpsEndpoint(endpoint string, body []byte) (string, error) {
 		return "", err
 	}
 
-	host, _, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		return "", err
-	}
-
 	u.Scheme = "https"
-	u.Host = net.JoinHostPort(host, strconv.Itoa(forbiddenResp.HTTPSPort))
+	u.Host = forbiddenResp.HTTPSAddr
 	return u.String(), nil
 }

--- a/nsqadmin/http_test.go
+++ b/nsqadmin/http_test.go
@@ -239,8 +239,8 @@ func TestHTTPNodesGET(t *testing.T) {
 	testNode := ns.Nodes[0]
 	test.Equal(t, hostname, testNode.Hostname)
 	test.Equal(t, "127.0.0.1", testNode.BroadcastAddress)
-	test.Equal(t, nsqds[0].RealTCPAddr().Port, testNode.TCPPort)
-	test.Equal(t, nsqds[0].RealHTTPAddr().Port, testNode.HTTPPort)
+	test.Equal(t, nsqds[0].RealTCPAddr().(*net.TCPAddr).Port, testNode.TCPPort)
+	test.Equal(t, nsqds[0].RealHTTPAddr().(*net.TCPAddr).Port, testNode.HTTPPort)
 	test.Equal(t, version.Binary, testNode.Version)
 	test.Equal(t, 0, len(testNode.Topics))
 }

--- a/nsqadmin/nsqadmin_test.go
+++ b/nsqadmin/nsqadmin_test.go
@@ -77,7 +77,7 @@ func TestTLSHTTPClient(t *testing.T) {
 	test.Equal(t, resp.StatusCode < 500, true)
 }
 
-func mustStartNSQD(opts *nsqd.Options) (*net.TCPAddr, *net.TCPAddr, *nsqd.NSQD) {
+func mustStartNSQD(opts *nsqd.Options) (net.Addr, net.Addr, *nsqd.NSQD) {
 	opts.TCPAddress = "127.0.0.1:0"
 	opts.HTTPAddress = "127.0.0.1:0"
 	opts.HTTPSAddress = "127.0.0.1:0"

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -637,9 +637,13 @@ func (c *clientV2) Flush() error {
 }
 
 func (c *clientV2) QueryAuthd() error {
-	remoteIP, _, err := net.SplitHostPort(c.String())
-	if err != nil {
-		return err
+	remoteIP := ""
+	if !c.nsqd.getOpts().UseUnixSockets {
+		ip, _, err := net.SplitHostPort(c.String())
+		if err != nil {
+			return err
+		}
+		remoteIP = ip
 	}
 
 	tlsEnabled := atomic.LoadInt32(&c.TLS) == 1

--- a/nsqd/http_test.go
+++ b/nsqd/http_test.go
@@ -527,7 +527,7 @@ func TestHTTPClientStats(t *testing.T) {
 		Memory *struct{} `json:"memory,omitempty"`
 	}
 
-	endpoint := fmt.Sprintf("http://127.0.0.1:%d/stats?format=json", httpAddr.Port)
+	endpoint := fmt.Sprintf("http://%s/stats?format=json", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
@@ -535,28 +535,28 @@ func TestHTTPClientStats(t *testing.T) {
 	test.Equal(t, 1, d.Topics[0].Channels[0].ClientCount)
 	test.NotNil(t, d.Memory)
 
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_clients=true", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_clients=true", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
 	test.Equal(t, 1, len(d.Topics[0].Channels[0].Clients))
 	test.Equal(t, 1, d.Topics[0].Channels[0].ClientCount)
 
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_clients=false", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_clients=false", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
 	test.Equal(t, 0, len(d.Topics[0].Channels[0].Clients))
 	test.Equal(t, 1, d.Topics[0].Channels[0].ClientCount)
 
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_mem=true", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_mem=true", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
 	test.NotNil(t, d.Memory)
 
 	d.Memory = nil
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_mem=false", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_mem=false", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -137,29 +137,40 @@ func New(opts *Options) (*NSQD, error) {
 	n.logf(LOG_INFO, version.String("nsqd"))
 	n.logf(LOG_INFO, "ID: %d", opts.ID)
 
+	socketType := "tcp"
+	if opts.UseUnixSockets {
+		socketType = "unix"
+	}
+
 	n.tcpServer = &tcpServer{nsqd: n}
-	n.tcpListener, err = net.Listen("tcp", opts.TCPAddress)
+	n.tcpListener, err = net.Listen(socketType, opts.TCPAddress)
 	if err != nil {
 		return nil, fmt.Errorf("listen (%s) failed - %s", opts.TCPAddress, err)
 	}
 	if opts.HTTPAddress != "" {
-		n.httpListener, err = net.Listen("tcp", opts.HTTPAddress)
+		n.httpListener, err = net.Listen(socketType, opts.HTTPAddress)
 		if err != nil {
 			return nil, fmt.Errorf("listen (%s) failed - %s", opts.HTTPAddress, err)
 		}
 	}
 	if n.tlsConfig != nil && opts.HTTPSAddress != "" {
-		n.httpsListener, err = tls.Listen("tcp", opts.HTTPSAddress, n.tlsConfig)
+		n.httpsListener, err = tls.Listen(socketType, opts.HTTPSAddress, n.tlsConfig)
 		if err != nil {
 			return nil, fmt.Errorf("listen (%s) failed - %s", opts.HTTPSAddress, err)
 		}
 	}
 	if opts.BroadcastHTTPPort == 0 {
-		opts.BroadcastHTTPPort = n.RealHTTPAddr().Port
+		tcpAddr, ok := n.RealHTTPAddr().(*net.TCPAddr)
+		if ok {
+			opts.BroadcastHTTPPort = tcpAddr.Port
+		}
 	}
 
 	if opts.BroadcastTCPPort == 0 {
-		opts.BroadcastTCPPort = n.RealTCPAddr().Port
+		tcpAddr, ok := n.RealTCPAddr().(*net.TCPAddr)
+		if ok {
+			opts.BroadcastTCPPort = tcpAddr.Port
+		}
 	}
 
 	if opts.StatsdPrefix != "" {
@@ -190,26 +201,26 @@ func (n *NSQD) triggerOptsNotification() {
 	}
 }
 
-func (n *NSQD) RealTCPAddr() *net.TCPAddr {
+func (n *NSQD) RealTCPAddr() net.Addr {
 	if n.tcpListener == nil {
 		return &net.TCPAddr{}
 	}
-	return n.tcpListener.Addr().(*net.TCPAddr)
+	return n.tcpListener.Addr()
 
 }
 
-func (n *NSQD) RealHTTPAddr() *net.TCPAddr {
+func (n *NSQD) RealHTTPAddr() net.Addr {
 	if n.httpListener == nil {
 		return &net.TCPAddr{}
 	}
-	return n.httpListener.Addr().(*net.TCPAddr)
+	return n.httpListener.Addr()
 }
 
-func (n *NSQD) RealHTTPSAddr() *net.TCPAddr {
+func (n *NSQD) RealHTTPSAddr() net.Addr {
 	if n.httpsListener == nil {
 		return &net.TCPAddr{}
 	}
-	return n.httpsListener.Addr().(*net.TCPAddr)
+	return n.httpsListener.Addr()
 }
 
 func (n *NSQD) SetHealth(err error) {

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"strconv"
@@ -239,7 +240,7 @@ func TestPauseMetadata(t *testing.T) {
 	test.Equal(t, false, isPaused(nsqd, 0, 0))
 }
 
-func mustStartNSQLookupd(opts *nsqlookupd.Options) (*net.TCPAddr, *net.TCPAddr, *nsqlookupd.NSQLookupd) {
+func mustStartNSQLookupd(opts *nsqlookupd.Options) (net.Addr, net.Addr, *nsqlookupd.NSQLookupd) {
 	opts.TCPAddress = "127.0.0.1:0"
 	opts.HTTPAddress = "127.0.0.1:0"
 	lookupd, err := nsqlookupd.New(opts)
@@ -361,7 +362,7 @@ func TestCluster(t *testing.T) {
 
 	test.Equal(t, hostname, topicData[0].Hostname)
 	test.Equal(t, "127.0.0.1", topicData[0].BroadcastAddress)
-	test.Equal(t, nsqd.RealTCPAddr().Port, topicData[0].TCPPort)
+	test.Equal(t, nsqd.RealTCPAddr().(*net.TCPAddr).Port, topicData[0].TCPPort)
 	test.Equal(t, false, topicData[0].Tombstoned)
 
 	channelData := d["channel:"+topicName+":ch"]
@@ -369,7 +370,7 @@ func TestCluster(t *testing.T) {
 
 	test.Equal(t, hostname, channelData[0].Hostname)
 	test.Equal(t, "127.0.0.1", channelData[0].BroadcastAddress)
-	test.Equal(t, nsqd.RealTCPAddr().Port, channelData[0].TCPPort)
+	test.Equal(t, nsqd.RealTCPAddr().(*net.TCPAddr).Port, channelData[0].TCPPort)
 	test.Equal(t, false, channelData[0].Tombstoned)
 
 	var lr struct {
@@ -388,7 +389,7 @@ func TestCluster(t *testing.T) {
 	test.Equal(t, 1, len(lr.Producers))
 	test.Equal(t, hostname, lr.Producers[0].Hostname)
 	test.Equal(t, "127.0.0.1", lr.Producers[0].BroadcastAddress)
-	test.Equal(t, nsqd.RealTCPAddr().Port, lr.Producers[0].TCPPort)
+	test.Equal(t, nsqd.RealTCPAddr().(*net.TCPAddr).Port, lr.Producers[0].TCPPort)
 	test.Equal(t, 1, len(lr.Channels))
 	test.Equal(t, "ch", lr.Channels[0])
 
@@ -437,4 +438,25 @@ func TestSetHealth(t *testing.T) {
 	test.Nil(t, nsqd.GetError())
 	test.Equal(t, "OK", nsqd.GetHealth())
 	test.Equal(t, true, nsqd.IsHealthy())
+}
+
+func TestUnixSocketStartup(t *testing.T) {
+	isSocket := func(path string) bool {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			return false
+		}
+		return fileInfo.Mode().Type() == fs.ModeSocket
+	}
+
+	opts := NewOptions()
+	opts.Logger = test.NewTestLogger(t)
+	opts.UseUnixSockets = true
+
+	_, _, nsqd := mustUnixSocketStartNSQD(opts)
+	defer os.RemoveAll(opts.DataPath)
+	defer nsqd.Exit()
+
+	test.Equal(t, isSocket(opts.TCPAddress), true)
+	test.Equal(t, isSocket(opts.HTTPAddress), true)
 }

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	AuthHTTPAddresses        []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
 	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
 	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout" cfg:"http_client_request_timeout"`
+	UseUnixSockets           bool          `flag:"use-unix-sockets" cfg:"use_unix_sockets"`
 
 	// diskqueue options
 	DataPath        string        `flag:"data-path"`

--- a/nsqd/protocol_v2_unixsocket_test.go
+++ b/nsqd/protocol_v2_unixsocket_test.go
@@ -8,14 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"math/rand"
 	"net"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
+	"path"
 	"runtime"
 	"strconv"
 	"sync"
@@ -29,10 +26,11 @@ import (
 	"github.com/nsqio/nsq/internal/test"
 )
 
-func mustStartNSQD(opts *Options) (net.Addr, net.Addr, *NSQD) {
-	opts.TCPAddress = "127.0.0.1:0"
-	opts.HTTPAddress = "127.0.0.1:0"
-	opts.HTTPSAddress = "127.0.0.1:0"
+func mustUnixSocketStartNSQD(opts *Options) (net.Addr, net.Addr, *NSQD) {
+	tmpDir := os.TempDir()
+	opts.TCPAddress = path.Join(tmpDir, fmt.Sprintf("nsqd-%d.sock", rand.Int()))
+	opts.HTTPAddress = path.Join(tmpDir, fmt.Sprintf("nsqd-%d.sock", rand.Int()))
+
 	if opts.DataPath == "" {
 		tmpDir, err := os.MkdirTemp("", "nsq-test-")
 		if err != nil {
@@ -53,8 +51,8 @@ func mustStartNSQD(opts *Options) (net.Addr, net.Addr, *NSQD) {
 	return nsqd.RealTCPAddr(), nsqd.RealHTTPAddr(), nsqd
 }
 
-func mustConnectNSQD(tcpAddr net.Addr) (net.Conn, error) {
-	conn, err := net.DialTimeout("tcp", tcpAddr.String(), time.Second)
+func mustUnixSocketConnectNSQD(addr net.Addr) (net.Conn, error) {
+	conn, err := net.DialTimeout("unix", addr.String(), time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -62,74 +60,13 @@ func mustConnectNSQD(tcpAddr net.Addr) (net.Conn, error) {
 	return conn, nil
 }
 
-func identify(t *testing.T, conn io.ReadWriter, extra map[string]interface{}, f int32) []byte {
-	ci := make(map[string]interface{})
-	ci["client_id"] = "test"
-	ci["feature_negotiation"] = true
-	for k, v := range extra {
-		ci[k] = v
-	}
-	cmd, _ := nsq.Identify(ci)
-	_, err := cmd.WriteTo(conn)
-	test.Nil(t, err)
-	resp, err := nsq.ReadResponse(conn)
-	test.Nil(t, err)
-	frameType, data, err := nsq.UnpackResponse(resp)
-	test.Nil(t, err)
-	test.Equal(t, frameType, f)
-	return data
-}
-
-func sub(t *testing.T, conn io.ReadWriter, topicName string, channelName string) {
-	_, err := nsq.Subscribe(topicName, channelName).WriteTo(conn)
-	test.Nil(t, err)
-	readValidate(t, conn, frameTypeResponse, "OK")
-}
-
-func authCmd(t *testing.T, conn io.ReadWriter, authSecret string, expectSuccess string) {
-	auth, _ := nsq.Auth(authSecret)
-	_, err := auth.WriteTo(conn)
-	test.Nil(t, err)
-	if expectSuccess != "" {
-		readValidate(t, conn, nsq.FrameTypeResponse, expectSuccess)
-	}
-}
-
-func subFail(t *testing.T, conn io.ReadWriter, topicName string, channelName string) {
-	_, err := nsq.Subscribe(topicName, channelName).WriteTo(conn)
-	test.Nil(t, err)
-	resp, _ := nsq.ReadResponse(conn)
-	frameType, _, _ := nsq.UnpackResponse(resp)
-	test.Equal(t, frameTypeError, frameType)
-}
-
-func readValidate(t *testing.T, conn io.Reader, f int32, d string) []byte {
-	resp, err := nsq.ReadResponse(conn)
-	test.Nil(t, err)
-	frameType, data, err := nsq.UnpackResponse(resp)
-	test.Nil(t, err)
-	test.Equal(t, f, frameType)
-	test.Equal(t, d, string(data))
-	return data
-}
-
-// test channel/topic names
-func TestChannelTopicNames(t *testing.T) {
-	test.Equal(t, true, protocol.IsValidChannelName("test"))
-	test.Equal(t, true, protocol.IsValidChannelName("test-with_period."))
-	test.Equal(t, true, protocol.IsValidChannelName("test#ephemeral"))
-	test.Equal(t, true, protocol.IsValidTopicName("test"))
-	test.Equal(t, true, protocol.IsValidTopicName("test-with_period."))
-	test.Equal(t, true, protocol.IsValidTopicName("test#ephemeral"))
-	test.Equal(t, false, protocol.IsValidTopicName("test:ephemeral"))
-}
-
 // exercise the basic operations of the V2 protocol
-func TestBasicV2(t *testing.T) {
+func TestUnixSocketBasicV2(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.ClientTimeout = 60 * time.Second
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
@@ -138,7 +75,7 @@ func TestBasicV2(t *testing.T) {
 	msg := NewMessage(topic.GenerateID(), []byte("test body"))
 	topic.PutMessage(msg)
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -158,13 +95,14 @@ func TestBasicV2(t *testing.T) {
 	test.Equal(t, uint16(1), msgOut.Attempts)
 }
 
-func TestMultipleConsumerV2(t *testing.T) {
+func TestUnixSocketMultipleConsumerV2(t *testing.T) {
 	msgChan := make(chan *Message)
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.ClientTimeout = 60 * time.Second
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
@@ -176,7 +114,7 @@ func TestMultipleConsumerV2(t *testing.T) {
 	topic.PutMessage(msg)
 
 	for _, i := range []string{"1", "2"} {
-		conn, err := mustConnectNSQD(tcpAddr)
+		conn, err := mustUnixSocketConnectNSQD(addr)
 		test.Nil(t, err)
 		defer conn.Close()
 
@@ -207,18 +145,19 @@ func TestMultipleConsumerV2(t *testing.T) {
 	test.Equal(t, uint16(1), msgOut.Attempts)
 }
 
-func TestClientTimeout(t *testing.T) {
+func TestUnixSocketClientTimeout(t *testing.T) {
 	topicName := "test_client_timeout_v2" + strconv.Itoa(int(time.Now().Unix()))
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.ClientTimeout = 150 * time.Millisecond
 	opts.LogLevel = LOG_DEBUG
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -244,17 +183,18 @@ func TestClientTimeout(t *testing.T) {
 done:
 }
 
-func TestClientHeartbeat(t *testing.T) {
+func TestUnixSocketClientHeartbeat(t *testing.T) {
 	topicName := "test_hb_v2" + strconv.Itoa(int(time.Now().Unix()))
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.ClientTimeout = 200 * time.Millisecond
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -280,18 +220,19 @@ func TestClientHeartbeat(t *testing.T) {
 	test.Nil(t, err)
 }
 
-func TestClientHeartbeatDisableSUB(t *testing.T) {
+func TestUnixSocketClientHeartbeatDisableSUB(t *testing.T) {
 	topicName := "test_hb_v2" + strconv.Itoa(int(time.Now().Unix()))
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.ClientTimeout = 200 * time.Millisecond
 	opts.LogLevel = LOG_DEBUG
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -301,15 +242,16 @@ func TestClientHeartbeatDisableSUB(t *testing.T) {
 	subFail(t, conn, topicName, "ch")
 }
 
-func TestClientHeartbeatDisable(t *testing.T) {
+func TestUnixSocketClientHeartbeatDisable(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.ClientTimeout = 100 * time.Millisecond
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -323,15 +265,16 @@ func TestClientHeartbeatDisable(t *testing.T) {
 	test.Nil(t, err)
 }
 
-func TestMaxHeartbeatIntervalValid(t *testing.T) {
+func TestUnixSocketMaxHeartbeatIntervalValid(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.MaxHeartbeatInterval = 300 * time.Second
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -341,15 +284,16 @@ func TestMaxHeartbeatIntervalValid(t *testing.T) {
 	}, frameTypeResponse)
 }
 
-func TestMaxHeartbeatIntervalInvalid(t *testing.T) {
+func TestUnixSocketMaxHeartbeatIntervalInvalid(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.MaxHeartbeatInterval = 300 * time.Second
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -360,16 +304,17 @@ func TestMaxHeartbeatIntervalInvalid(t *testing.T) {
 	test.Equal(t, "E_BAD_BODY IDENTIFY heartbeat interval (300001) is invalid", string(data))
 }
 
-func TestPausing(t *testing.T) {
+func TestUnixSocketPausing(t *testing.T) {
 	topicName := "test_pause_v2" + strconv.Itoa(int(time.Now().Unix()))
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -426,14 +371,15 @@ func TestPausing(t *testing.T) {
 	test.Equal(t, []byte("test body3"), msg.Body)
 }
 
-func TestEmptyCommand(t *testing.T) {
+func TestUnixSocketEmptyCommand(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -443,17 +389,18 @@ func TestEmptyCommand(t *testing.T) {
 	// if we didn't panic here we're good, see issue #120
 }
 
-func TestSizeLimits(t *testing.T) {
+func TestUnixSocketSizeLimits(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MaxMsgSize = 100
 	opts.MaxBodySize = 1000
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -479,7 +426,7 @@ func TestSizeLimits(t *testing.T) {
 	test.Equal(t, "E_BAD_MESSAGE PUB message too big 105 > 100", string(data))
 
 	// need to reconnect
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -492,7 +439,7 @@ func TestSizeLimits(t *testing.T) {
 	test.Equal(t, "E_BAD_MESSAGE PUB invalid message body size 0", string(data))
 
 	// need to reconnect
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -523,7 +470,7 @@ func TestSizeLimits(t *testing.T) {
 	test.Equal(t, "E_BAD_BODY MPUB body too big 1148 > 1000", string(data))
 
 	// need to reconnect
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -542,7 +489,7 @@ func TestSizeLimits(t *testing.T) {
 	test.Equal(t, "E_BAD_MESSAGE MPUB invalid message(5) body size 0", string(data))
 
 	// need to reconnect
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -560,15 +507,16 @@ func TestSizeLimits(t *testing.T) {
 	test.Equal(t, "E_BAD_MESSAGE MPUB message too big 101 > 100", string(data))
 }
 
-func TestDPUB(t *testing.T) {
+func TestUnixSocketDPUB(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -603,18 +551,19 @@ func TestDPUB(t *testing.T) {
 	test.Equal(t, "E_INVALID DPUB timeout 3600100 out of range 0-3600000", string(data))
 }
 
-func TestTouch(t *testing.T) {
+func TestUnixSocketTouch(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MsgTimeout = 150 * time.Millisecond
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	topicName := "test_touch" + strconv.Itoa(int(time.Now().Unix()))
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -649,18 +598,19 @@ func TestTouch(t *testing.T) {
 	test.Equal(t, uint64(0), channel.timeoutCount)
 }
 
-func TestMaxRdyCount(t *testing.T) {
+func TestUnixSocketMaxRdyCount(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MaxRdyCount = 50
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	topicName := "test_max_rdy_count" + strconv.Itoa(int(time.Now().Unix()))
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -697,14 +647,15 @@ func TestMaxRdyCount(t *testing.T) {
 	test.Equal(t, "E_INVALID RDY count 51 out of range 0-50", string(data))
 }
 
-func TestFatalError(t *testing.T) {
+func TestUnixSocketFatalError(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -721,19 +672,20 @@ func TestFatalError(t *testing.T) {
 	test.NotNil(t, err)
 }
 
-func TestOutputBuffering(t *testing.T) {
+func TestUnixSocketOutputBuffering(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MaxOutputBufferSize = 512 * 1024
 	opts.MaxOutputBufferTimeout = time.Second
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	topicName := "test_output_buffering" + strconv.Itoa(int(time.Now().Unix()))
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -773,17 +725,18 @@ func TestOutputBuffering(t *testing.T) {
 	test.Equal(t, msg.ID, msgOut.ID)
 }
 
-func TestOutputBufferingValidity(t *testing.T) {
+func TestUnixSocketOutputBufferingValidity(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MaxOutputBufferSize = 512 * 1024
 	opts.MaxOutputBufferTimeout = time.Second
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -805,7 +758,7 @@ func TestOutputBufferingValidity(t *testing.T) {
 	}, frameTypeError)
 	test.Equal(t, fmt.Sprintf("E_BAD_BODY IDENTIFY output buffer size (%d) is invalid", 512*1024+1), string(data))
 
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -816,17 +769,18 @@ func TestOutputBufferingValidity(t *testing.T) {
 	test.Equal(t, "E_BAD_BODY IDENTIFY output buffer timeout (1001) is invalid", string(data))
 }
 
-func TestTLS(t *testing.T) {
+func TestUnixSocketTLS(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.TLSCert = "./test/certs/server.pem"
 	opts.TLSKey = "./test/certs/server.key"
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -855,27 +809,28 @@ func TestTLS(t *testing.T) {
 	test.Equal(t, []byte("OK"), data)
 }
 
-func TestTLSRequired(t *testing.T) {
+func TestUnixSocketTLSRequired(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.TLSCert = "./test/certs/server.pem"
 	opts.TLSKey = "./test/certs/server.key"
 	opts.TLSRequired = TLSRequiredExceptHTTP
 
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	topicName := "test_tls_required" + strconv.Itoa(int(time.Now().Unix()))
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
 	subFail(t, conn, topicName, "ch")
 
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -904,20 +859,21 @@ func TestTLSRequired(t *testing.T) {
 	test.Equal(t, []byte("OK"), data)
 }
 
-func TestTLSAuthRequire(t *testing.T) {
+func TestUnixSocketTLSAuthRequire(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.TLSCert = "./test/certs/server.pem"
 	opts.TLSKey = "./test/certs/server.key"
 	opts.TLSClientAuthPolicy = "require"
 
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	// No Certs
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -938,7 +894,7 @@ func TestTLSAuthRequire(t *testing.T) {
 	test.NotNil(t, err)
 
 	// With Unsigned Cert
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -970,8 +926,9 @@ func TestTLSAuthRequire(t *testing.T) {
 
 }
 
-func TestTLSAuthRequireVerify(t *testing.T) {
+func TestUnixSocketTLSAuthRequireVerify(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.TLSCert = "./test/certs/server.pem"
@@ -979,12 +936,12 @@ func TestTLSAuthRequireVerify(t *testing.T) {
 	opts.TLSRootCAFile = "./test/certs/ca.pem"
 	opts.TLSClientAuthPolicy = "require-verify"
 
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	// with no cert
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1005,7 +962,7 @@ func TestTLSAuthRequireVerify(t *testing.T) {
 	test.NotNil(t, err)
 
 	// with invalid cert
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1029,7 +986,7 @@ func TestTLSAuthRequireVerify(t *testing.T) {
 	test.NotNil(t, err)
 
 	// with valid cert
-	conn, err = mustConnectNSQD(tcpAddr)
+	conn, err = mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1059,16 +1016,17 @@ func TestTLSAuthRequireVerify(t *testing.T) {
 	test.Equal(t, []byte("OK"), data)
 }
 
-func TestDeflate(t *testing.T) {
+func TestUnixSocketDeflate(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.DeflateEnabled = true
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1090,21 +1048,17 @@ func TestDeflate(t *testing.T) {
 	test.Equal(t, []byte("OK"), data)
 }
 
-type readWriter struct {
-	io.Reader
-	io.Writer
-}
-
-func TestSnappy(t *testing.T) {
+func TestUnixSocketSnappy(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.SnappyEnabled = true
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1149,18 +1103,19 @@ func TestSnappy(t *testing.T) {
 	test.Equal(t, msg.Body, msgOut.Body)
 }
 
-func TestTLSDeflate(t *testing.T) {
+func TestUnixSocketTLSDeflate(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.DeflateEnabled = true
 	opts.TLSCert = "./test/certs/cert.pem"
 	opts.TLSKey = "./test/certs/key.pem"
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1200,7 +1155,7 @@ func TestTLSDeflate(t *testing.T) {
 	test.Equal(t, []byte("OK"), data)
 }
 
-func TestSampling(t *testing.T) {
+func TestUnixSocketSampling(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	num := 10000
@@ -1208,14 +1163,15 @@ func TestSampling(t *testing.T) {
 	slack := 5
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MaxRdyCount = int64(num)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1273,18 +1229,19 @@ func TestSampling(t *testing.T) {
 	test.Equal(t, true, numInFlight >= int(float64(num)*float64(sampleRate-slack)/100.0))
 }
 
-func TestTLSSnappy(t *testing.T) {
+func TestUnixSocketTLSSnappy(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.SnappyEnabled = true
 	opts.TLSCert = "./test/certs/cert.pem"
 	opts.TLSKey = "./test/certs/key.pem"
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1324,12 +1281,13 @@ func TestTLSSnappy(t *testing.T) {
 	test.Equal(t, []byte("OK"), data)
 }
 
-func TestClientMsgTimeout(t *testing.T) {
+func TestUnixSocketClientMsgTimeout(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.QueueScanRefreshInterval = 100 * time.Millisecond
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
@@ -1344,7 +1302,7 @@ func TestClientMsgTimeout(t *testing.T) {
 	// it does not reflect a realistically possible condition
 	topic.PutMessage(NewMessage(topic.GenerateID(), make([]byte, 100)))
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1383,15 +1341,16 @@ func TestClientMsgTimeout(t *testing.T) {
 		string(data))
 }
 
-func TestBadFin(t *testing.T) {
+func TestUnixSocketBadFin(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1409,18 +1368,19 @@ func TestBadFin(t *testing.T) {
 	test.Equal(t, "E_INVALID invalid message ID", string(data))
 }
 
-func TestReqTimeoutRange(t *testing.T) {
+func TestUnixSocketReqTimeoutRange(t *testing.T) {
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 	opts.MaxReqTimeout = 1 * time.Minute
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
 	topicName := "test_req" + strconv.Itoa(int(time.Now().Unix()))
 
-	conn, err := mustConnectNSQD(tcpAddr)
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	test.Nil(t, err)
 	defer conn.Close()
 
@@ -1469,135 +1429,31 @@ func TestReqTimeoutRange(t *testing.T) {
 	test.Equal(t, true, pqItem.Priority >= minTs)
 }
 
-func TestClientAuth(t *testing.T) {
-	authResponse := `{"ttl":1, "authorizations":[]}`
-	authSecret := "testsecret"
-	authError := "E_UNAUTHORIZED AUTH no authorizations found"
-	authSuccess := ""
-	tlsEnabled := false
-	commonName := ""
-	runAuthTest(t, authResponse, authSecret, authError, authSuccess, tlsEnabled, commonName)
-
-	// now one that will succeed
-	authResponse = `{"ttl":10, "authorizations":
-		[{"topic":"test", "channels":[".*"], "permissions":["subscribe","publish"]}]
-	}`
-	authError = ""
-	authSuccess = `{"identity":"","identity_url":"","permission_count":1}`
-	runAuthTest(t, authResponse, authSecret, authError, authSuccess, tlsEnabled, commonName)
-
-	// one with TLS enabled
-	tlsEnabled = true
-	commonName = "test.local"
-	runAuthTest(t, authResponse, authSecret, authError, authSuccess, tlsEnabled, commonName)
-}
-
-func runAuthTest(t *testing.T, authResponse string, authSecret string, authError string,
-	authSuccess string, tlsEnabled bool, commonName string) {
-	var err error
-	var expectedRemoteIP string
-	expectedTLS := "false"
-	if tlsEnabled {
-		expectedTLS = "true"
-	}
-
-	authd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("in test auth handler %s", r.RequestURI)
-		r.ParseForm()
-		test.Equal(t, expectedRemoteIP, r.Form.Get("remote_ip"))
-		test.Equal(t, expectedTLS, r.Form.Get("tls"))
-		test.Equal(t, commonName, r.Form.Get("common_name"))
-		test.Equal(t, authSecret, r.Form.Get("secret"))
-		fmt.Fprint(w, authResponse)
-	}))
-	defer authd.Close()
-
-	addr, err := url.Parse(authd.URL)
-	test.Nil(t, err)
-
-	opts := NewOptions()
-	opts.Logger = test.NewTestLogger(t)
-	opts.LogLevel = LOG_DEBUG
-	opts.AuthHTTPAddresses = []string{addr.Host}
-	if tlsEnabled {
-		opts.TLSCert = "./test/certs/server.pem"
-		opts.TLSKey = "./test/certs/server.key"
-		opts.TLSClientAuthPolicy = "require"
-	}
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
-	defer os.RemoveAll(opts.DataPath)
-	defer nsqd.Exit()
-
-	conn, err := mustConnectNSQD(tcpAddr)
-	test.Nil(t, err)
-	defer conn.Close()
-
-	data := identify(t, conn, map[string]interface{}{
-		"tls_v1": tlsEnabled,
-	}, frameTypeResponse)
-	r := struct {
-		TLSv1 bool `json:"tls_v1"`
-	}{}
-	err = json.Unmarshal(data, &r)
-	test.Nil(t, err)
-	test.Equal(t, tlsEnabled, r.TLSv1)
-
-	var c io.ReadWriter
-	var tlsConn *tls.Conn
-	c = conn
-	if tlsEnabled {
-		cert, err := tls.LoadX509KeyPair("./test/certs/cert.pem", "./test/certs/key.pem")
-		test.Nil(t, err)
-		tlsConfig := &tls.Config{
-			Certificates:       []tls.Certificate{cert},
-			InsecureSkipVerify: true,
-		}
-		tlsConn = tls.Client(conn, tlsConfig)
-		err = tlsConn.Handshake()
-		test.Nil(t, err)
-		c = tlsConn
-
-		resp, _ := nsq.ReadResponse(tlsConn)
-		frameType, data, _ := nsq.UnpackResponse(resp)
-		t.Logf("frameType: %d, data: %s", frameType, data)
-		test.Equal(t, frameTypeResponse, frameType)
-		test.Equal(t, []byte("OK"), data)
-	}
-
-	expectedRemoteIP, _, _ = net.SplitHostPort(conn.LocalAddr().String())
-
-	authCmd(t, c, authSecret, authSuccess)
-	if authError != "" {
-		readValidate(t, c, frameTypeError, authError)
-	} else {
-		sub(t, c, "test", "ch")
-	}
-}
-
-func TestIOLoopReturnsClientErrWhenSendFails(t *testing.T) {
+func TestUnixSocketIOLoopReturnsClientErrWhenSendFails(t *testing.T) {
 	fakeConn := test.NewFakeNetConn()
 	fakeConn.WriteFunc = func(b []byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	testIOLoopReturnsClientErr(t, fakeConn)
+	testUnixSocketIOLoopReturnsClientErr(t, fakeConn)
 }
 
-func TestIOLoopReturnsClientErrWhenSendSucceeds(t *testing.T) {
+func TestUnixSocketIOLoopReturnsClientErrWhenSendSucceeds(t *testing.T) {
 	fakeConn := test.NewFakeNetConn()
 	fakeConn.WriteFunc = func(b []byte) (int, error) {
 		return len(b), nil
 	}
 
-	testIOLoopReturnsClientErr(t, fakeConn)
+	testUnixSocketIOLoopReturnsClientErr(t, fakeConn)
 }
 
-func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
+func testUnixSocketIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 	fakeConn.ReadFunc = func(b []byte) (int, error) {
 		return copy(b, []byte("INVALID_COMMAND\n")), nil
 	}
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(t)
 	opts.LogLevel = LOG_DEBUG
 
@@ -1613,9 +1469,10 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 	test.NotNil(t, err.(*protocol.FatalClientErr))
 }
 
-func BenchmarkProtocolV2Exec(b *testing.B) {
+func BenchmarkUnixSocketProtocolV2Exec(b *testing.B) {
 	b.StopTimer()
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(b)
 	nsqd, _ := New(opts)
 	p := &protocolV2{nsqd}
@@ -1628,15 +1485,16 @@ func BenchmarkProtocolV2Exec(b *testing.B) {
 	}
 }
 
-func benchmarkProtocolV2PubMultiTopic(b *testing.B, numTopics int) {
+func benchmarkUnixSocketProtocolV2PubMultiTopic(b *testing.B, numTopics int) {
 	var wg sync.WaitGroup
 	b.StopTimer()
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	size := 200
 	batchSize := int(opts.MaxBodySize) / (size + 4)
 	opts.Logger = test.NewTestLogger(b)
 	opts.MemQueueSize = int64(b.N)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	msg := make([]byte, size)
 	batch := make([][]byte, batchSize)
@@ -1650,7 +1508,7 @@ func benchmarkProtocolV2PubMultiTopic(b *testing.B, numTopics int) {
 		topicName := fmt.Sprintf("bench_v2_pub_multi_topic_%d_%d", j, time.Now().Unix())
 		wg.Add(1)
 		go func() {
-			conn, err := mustConnectNSQD(tcpAddr)
+			conn, err := mustUnixSocketConnectNSQD(addr)
 			if err != nil {
 				panic(err.Error())
 			}
@@ -1696,21 +1554,34 @@ func benchmarkProtocolV2PubMultiTopic(b *testing.B, numTopics int) {
 	nsqd.Exit()
 }
 
-func BenchmarkProtocolV2PubMultiTopic1(b *testing.B)  { benchmarkProtocolV2PubMultiTopic(b, 1) }
-func BenchmarkProtocolV2PubMultiTopic2(b *testing.B)  { benchmarkProtocolV2PubMultiTopic(b, 2) }
-func BenchmarkProtocolV2PubMultiTopic4(b *testing.B)  { benchmarkProtocolV2PubMultiTopic(b, 4) }
-func BenchmarkProtocolV2PubMultiTopic8(b *testing.B)  { benchmarkProtocolV2PubMultiTopic(b, 8) }
-func BenchmarkProtocolV2PubMultiTopic16(b *testing.B) { benchmarkProtocolV2PubMultiTopic(b, 16) }
-func BenchmarkProtocolV2PubMultiTopic32(b *testing.B) { benchmarkProtocolV2PubMultiTopic(b, 32) }
+func BenchmarkUnixSocketProtocolV2PubMultiTopic1(b *testing.B) {
+	benchmarkUnixSocketProtocolV2PubMultiTopic(b, 1)
+}
+func BenchmarkUnixSocketkProtocolV2PubMultiTopic2(b *testing.B) {
+	benchmarkUnixSocketProtocolV2PubMultiTopic(b, 2)
+}
+func BenchmarkUnixSocketProtocolV2PubMultiTopic4(b *testing.B) {
+	benchmarkUnixSocketProtocolV2PubMultiTopic(b, 4)
+}
+func BenchmarkUnixSocketProtocolV2PubMultiTopic8(b *testing.B) {
+	benchmarkUnixSocketProtocolV2PubMultiTopic(b, 8)
+}
+func BenchmarkUnixSocketProtocolV2PubMultiTopic16(b *testing.B) {
+	benchmarkUnixSocketProtocolV2PubMultiTopic(b, 16)
+}
+func BenchmarkUnixSocketProtocolV2PubMultiTopic32(b *testing.B) {
+	benchmarkUnixSocketProtocolV2PubMultiTopic(b, 32)
+}
 
-func benchmarkProtocolV2Pub(b *testing.B, size int) {
+func benchmarkUnixSocketProtocolV2Pub(b *testing.B, size int) {
 	var wg sync.WaitGroup
 	b.StopTimer()
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	batchSize := int(opts.MaxBodySize) / (size + 4)
 	opts.Logger = test.NewTestLogger(b)
 	opts.MemQueueSize = int64(b.N)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	msg := make([]byte, size)
 	batch := make([][]byte, batchSize)
@@ -1724,7 +1595,7 @@ func benchmarkProtocolV2Pub(b *testing.B, size int) {
 	for j := 0; j < runtime.GOMAXPROCS(0); j++ {
 		wg.Add(1)
 		go func() {
-			conn, err := mustConnectNSQD(tcpAddr)
+			conn, err := mustUnixSocketConnectNSQD(addr)
 			if err != nil {
 				panic(err.Error())
 			}
@@ -1770,27 +1641,34 @@ func benchmarkProtocolV2Pub(b *testing.B, size int) {
 	nsqd.Exit()
 }
 
-func BenchmarkProtocolV2Pub256(b *testing.B)  { benchmarkProtocolV2Pub(b, 256) }
-func BenchmarkProtocolV2Pub512(b *testing.B)  { benchmarkProtocolV2Pub(b, 512) }
-func BenchmarkProtocolV2Pub1k(b *testing.B)   { benchmarkProtocolV2Pub(b, 1024) }
-func BenchmarkProtocolV2Pub2k(b *testing.B)   { benchmarkProtocolV2Pub(b, 2*1024) }
-func BenchmarkProtocolV2Pub4k(b *testing.B)   { benchmarkProtocolV2Pub(b, 4*1024) }
-func BenchmarkProtocolV2Pub8k(b *testing.B)   { benchmarkProtocolV2Pub(b, 8*1024) }
-func BenchmarkProtocolV2Pub16k(b *testing.B)  { benchmarkProtocolV2Pub(b, 16*1024) }
-func BenchmarkProtocolV2Pub32k(b *testing.B)  { benchmarkProtocolV2Pub(b, 32*1024) }
-func BenchmarkProtocolV2Pub64k(b *testing.B)  { benchmarkProtocolV2Pub(b, 64*1024) }
-func BenchmarkProtocolV2Pub128k(b *testing.B) { benchmarkProtocolV2Pub(b, 128*1024) }
-func BenchmarkProtocolV2Pub256k(b *testing.B) { benchmarkProtocolV2Pub(b, 256*1024) }
-func BenchmarkProtocolV2Pub512k(b *testing.B) { benchmarkProtocolV2Pub(b, 512*1024) }
-func BenchmarkProtocolV2Pub1m(b *testing.B)   { benchmarkProtocolV2Pub(b, 1024*1024) }
+func BenchmarkUnixSocketProtocolV2Pub256(b *testing.B) { benchmarkUnixSocketProtocolV2Pub(b, 256) }
+func BenchmarkUnixSocketProtocolV2Pub512(b *testing.B) { benchmarkUnixSocketProtocolV2Pub(b, 512) }
+func BenchmarkUnixSocketProtocolV2Pub1k(b *testing.B)  { benchmarkUnixSocketProtocolV2Pub(b, 1024) }
+func BenchmarkUnixSocketProtocolV2Pub2k(b *testing.B)  { benchmarkUnixSocketProtocolV2Pub(b, 2*1024) }
+func BenchmarkUnixSocketProtocolV2Pub4k(b *testing.B)  { benchmarkUnixSocketProtocolV2Pub(b, 4*1024) }
+func BenchmarkUnixSocketProtocolV2Pub8k(b *testing.B)  { benchmarkUnixSocketProtocolV2Pub(b, 8*1024) }
+func BenchmarkUnixSocketProtocolV2Pub16k(b *testing.B) { benchmarkUnixSocketProtocolV2Pub(b, 16*1024) }
+func BenchmarkUnixSocketProtocolV2Pub32k(b *testing.B) { benchmarkUnixSocketProtocolV2Pub(b, 32*1024) }
+func BenchmarkUnixSocketProtocolV2Pub64k(b *testing.B) { benchmarkUnixSocketProtocolV2Pub(b, 64*1024) }
+func BenchmarkUnixSocketProtocolV2Pub128k(b *testing.B) {
+	benchmarkUnixSocketProtocolV2Pub(b, 128*1024)
+}
+func BenchmarkUnixSocketProtocolV2Pub256k(b *testing.B) {
+	benchmarkUnixSocketProtocolV2Pub(b, 256*1024)
+}
+func BenchmarkUnixSocketProtocolV2Pub512k(b *testing.B) {
+	benchmarkUnixSocketProtocolV2Pub(b, 512*1024)
+}
+func BenchmarkUnixSocketProtocolV2Pub1m(b *testing.B) { benchmarkUnixSocketProtocolV2Pub(b, 1024*1024) }
 
-func benchmarkProtocolV2Sub(b *testing.B, size int) {
+func benchmarkUnixSocketProtocolV2Sub(b *testing.B, size int) {
 	var wg sync.WaitGroup
 	b.StopTimer()
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(b)
 	opts.MemQueueSize = int64(b.N)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	msg := make([]byte, size)
 	topicName := "bench_v2_sub" + strconv.Itoa(b.N) + strconv.Itoa(int(time.Now().Unix()))
@@ -1807,7 +1685,7 @@ func benchmarkProtocolV2Sub(b *testing.B, size int) {
 	for j := 0; j < workers; j++ {
 		wg.Add(1)
 		go func() {
-			subWorker(b.N, workers, tcpAddr, topicName, rdyChan, goChan)
+			subWorker(b.N, workers, addr, topicName, rdyChan, goChan)
 			wg.Done()
 		}()
 		<-rdyChan
@@ -1821,8 +1699,8 @@ func benchmarkProtocolV2Sub(b *testing.B, size int) {
 	nsqd.Exit()
 }
 
-func subWorker(n int, workers int, tcpAddr net.Addr, topicName string, rdyChan chan int, goChan chan int) {
-	conn, err := mustConnectNSQD(tcpAddr)
+func subUnixSocketWorker(n int, workers int, addr net.Addr, topicName string, rdyChan chan int, goChan chan int) {
+	conn, err := mustUnixSocketConnectNSQD(addr)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -1863,28 +1741,35 @@ func subWorker(n int, workers int, tcpAddr net.Addr, topicName string, rdyChan c
 	}
 }
 
-func BenchmarkProtocolV2Sub256(b *testing.B)  { benchmarkProtocolV2Sub(b, 256) }
-func BenchmarkProtocolV2Sub512(b *testing.B)  { benchmarkProtocolV2Sub(b, 512) }
-func BenchmarkProtocolV2Sub1k(b *testing.B)   { benchmarkProtocolV2Sub(b, 1024) }
-func BenchmarkProtocolV2Sub2k(b *testing.B)   { benchmarkProtocolV2Sub(b, 2*1024) }
-func BenchmarkProtocolV2Sub4k(b *testing.B)   { benchmarkProtocolV2Sub(b, 4*1024) }
-func BenchmarkProtocolV2Sub8k(b *testing.B)   { benchmarkProtocolV2Sub(b, 8*1024) }
-func BenchmarkProtocolV2Sub16k(b *testing.B)  { benchmarkProtocolV2Sub(b, 16*1024) }
-func BenchmarkProtocolV2Sub32k(b *testing.B)  { benchmarkProtocolV2Sub(b, 32*1024) }
-func BenchmarkProtocolV2Sub64k(b *testing.B)  { benchmarkProtocolV2Sub(b, 64*1024) }
-func BenchmarkProtocolV2Sub128k(b *testing.B) { benchmarkProtocolV2Sub(b, 128*1024) }
-func BenchmarkProtocolV2Sub256k(b *testing.B) { benchmarkProtocolV2Sub(b, 256*1024) }
-func BenchmarkProtocolV2Sub512k(b *testing.B) { benchmarkProtocolV2Sub(b, 512*1024) }
-func BenchmarkProtocolV2Sub1m(b *testing.B)   { benchmarkProtocolV2Sub(b, 1024*1024) }
+func BenchmarkUnixSocketProtocolV2Sub256(b *testing.B) { benchmarkUnixSocketProtocolV2Sub(b, 256) }
+func BenchmarkUnixSocketProtocolV2Sub512(b *testing.B) { benchmarkUnixSocketProtocolV2Sub(b, 512) }
+func BenchmarkUnixSocketProtocolV2Sub1k(b *testing.B)  { benchmarkUnixSocketProtocolV2Sub(b, 1024) }
+func BenchmarkUnixSocketProtocolV2Sub2k(b *testing.B)  { benchmarkUnixSocketProtocolV2Sub(b, 2*1024) }
+func BenchmarkUnixSocketProtocolV2Sub4k(b *testing.B)  { benchmarkUnixSocketProtocolV2Sub(b, 4*1024) }
+func BenchmarkUnixSocketProtocolV2Sub8k(b *testing.B)  { benchmarkUnixSocketProtocolV2Sub(b, 8*1024) }
+func BenchmarkUnixSocketProtocolV2Sub16k(b *testing.B) { benchmarkUnixSocketProtocolV2Sub(b, 16*1024) }
+func BenchmarkUnixSocketProtocolV2Sub32k(b *testing.B) { benchmarkUnixSocketProtocolV2Sub(b, 32*1024) }
+func BenchmarkUnixSocketProtocolV2Sub64k(b *testing.B) { benchmarkUnixSocketProtocolV2Sub(b, 64*1024) }
+func BenchmarkUnixSocketProtocolV2Sub128k(b *testing.B) {
+	benchmarkUnixSocketProtocolV2Sub(b, 128*1024)
+}
+func BenchmarkUnixSocketProtocolV2Sub256k(b *testing.B) {
+	benchmarkUnixSocketProtocolV2Sub(b, 256*1024)
+}
+func BenchmarkUnixSocketProtocolV2Sub512k(b *testing.B) {
+	benchmarkUnixSocketProtocolV2Sub(b, 512*1024)
+}
+func BenchmarkUnixSocketProtocolV2Sub1m(b *testing.B) { benchmarkUnixSocketProtocolV2Sub(b, 1024*1024) }
 
-func benchmarkProtocolV2MultiSub(b *testing.B, num int) {
+func benchmarkUnixSocketProtocolV2MultiSub(b *testing.B, num int) {
 	var wg sync.WaitGroup
 	b.StopTimer()
 
 	opts := NewOptions()
+	opts.UseUnixSockets = true
 	opts.Logger = test.NewTestLogger(b)
 	opts.MemQueueSize = int64(b.N)
-	tcpAddr, _, nsqd := mustStartNSQD(opts)
+	addr, _, nsqd := mustUnixSocketStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	msg := make([]byte, 256)
 	b.SetBytes(int64(len(msg) * num))
@@ -1904,7 +1789,7 @@ func benchmarkProtocolV2MultiSub(b *testing.B, num int) {
 		for j := 0; j < workers; j++ {
 			wg.Add(1)
 			go func() {
-				subWorker(b.N, workers, tcpAddr, topicName, rdyChan, goChan)
+				subUnixSocketWorker(b.N, workers, addr, topicName, rdyChan, goChan)
 				wg.Done()
 			}()
 			<-rdyChan
@@ -1919,8 +1804,18 @@ func benchmarkProtocolV2MultiSub(b *testing.B, num int) {
 	nsqd.Exit()
 }
 
-func BenchmarkProtocolV2MultiSub1(b *testing.B)  { benchmarkProtocolV2MultiSub(b, 1) }
-func BenchmarkProtocolV2MultiSub2(b *testing.B)  { benchmarkProtocolV2MultiSub(b, 2) }
-func BenchmarkProtocolV2MultiSub4(b *testing.B)  { benchmarkProtocolV2MultiSub(b, 4) }
-func BenchmarkProtocolV2MultiSub8(b *testing.B)  { benchmarkProtocolV2MultiSub(b, 8) }
-func BenchmarkProtocolV2MultiSub16(b *testing.B) { benchmarkProtocolV2MultiSub(b, 16) }
+func BenchmarkUnixSocketProtocolV2MultiSub2(b *testing.B) {
+	benchmarkUnixSocketProtocolV2MultiSub(b, 2)
+}
+func BenchmarkUnixSocketProtocolV2MultiSub1(b *testing.B) {
+	benchmarkUnixSocketProtocolV2MultiSub(b, 1)
+}
+func BenchmarkUnixSocketProtocolV2MultiSub4(b *testing.B) {
+	benchmarkUnixSocketProtocolV2MultiSub(b, 4)
+}
+func BenchmarkUnixSocketProtocolV2MultiSub8(b *testing.B) {
+	benchmarkUnixSocketProtocolV2MultiSub(b, 8)
+}
+func BenchmarkUnixSocketProtocolV2MultiSub16(b *testing.B) {
+	benchmarkUnixSocketProtocolV2MultiSub(b, 16)
+}

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -111,7 +111,7 @@ func TestClientAttributes(t *testing.T) {
 		} `json:"topics"`
 	}
 
-	endpoint := fmt.Sprintf("http://127.0.0.1:%d/stats?format=json", httpAddr.Port)
+	endpoint := fmt.Sprintf("http://%s/stats?format=json", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 


### PR DESCRIPTION
Example to run with unix sockets listeners:
```
nsqd --use-unix-sockets --tcp-address /var/run/nsqd.sock --http-address /var/run/nsqd-http.sock
```