### PR TITLE
Add removal of hanging unix socket

### DIFF
--- a/debian/imunify-nsq.postrm
+++ b/debian/imunify-nsq.postrm
@@ -4,5 +4,6 @@ set -e
 
 if [ "$1" = "remove" ]; then
     rm -rf /var/lib/imunify-nsqd
+    rm -rf /var/run/imunify-nsqd.sock
 fi
 #DEBHELPER#

--- a/debian/imunify-nsq.postrm
+++ b/debian/imunify-nsq.postrm
@@ -5,5 +5,6 @@ set -e
 if [ "$1" = "remove" ]; then
     rm -rf /var/lib/imunify-nsqd
     rm -rf /var/run/imunify-nsqd.sock
+    rm -rf /var/run/imunify-nsqd-http.sock
 fi
 #DEBHELPER#

--- a/imunify-nsq.spec
+++ b/imunify-nsq.spec
@@ -96,7 +96,7 @@ fi
 
 if [ $1 -eq 0 ] ; then
     # uninstall
-    rm -rf /var/lib/imunify-nsqd
+    rm -rf /var/run/imunify-nsqd.sock
 fi
 
 %changelog

--- a/imunify-nsq.spec
+++ b/imunify-nsq.spec
@@ -97,6 +97,7 @@ fi
 if [ $1 -eq 0 ] ; then
     # uninstall
     rm -rf /var/run/imunify-nsqd.sock
+    rm -rf /var/run/imunify-nsqd-http.sock
 fi
 
 %changelog


### PR DESCRIPTION
on centos
`rm -rf /var/lib/imunify-nsqd`
not needed since already handled by %files directive
unix socket removal is necessary
